### PR TITLE
refactor: update CSS imports to use new syntax and fix hover typo

### DIFF
--- a/dist/css/main.css
+++ b/dist/css/main.css
@@ -1,10 +1,3 @@
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-  outline: 0;
-}
-
 header {
   width: 100%;
 }
@@ -46,7 +39,7 @@ i {
   transition: background-color 0.8s;
 }
 
-.header-button:houver {
+.header-button:hover {
   border: 1px solid #d34040;
   background-color: #d34040;
 }
@@ -325,6 +318,13 @@ i {
     max-width: 64px;
   }
 }
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  outline: 0;
+}
+
 body {
   font-family: "Sora", sans-serif;
   width: 100%;

--- a/src/styles/_header.scss
+++ b/src/styles/_header.scss
@@ -1,3 +1,5 @@
+@use "colors" as *;
+
 header{
     width: 100%;
 }
@@ -41,7 +43,7 @@ i{
     transition: background-color 0.8s;
 }
 
-.header-button:houver{
+.header-button:hover{
     border: 1px solid $red-light;
     background-color: $red-light;
 }

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -1,4 +1,4 @@
-@import "colors";
+@use "colors" as *;
 
 .container {
     max-width: 1440px;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,13 +1,13 @@
+@use "colors" as *;
+@use "header";
+@use "layout";
+
 *{
     margin: 0;
     padding: 0;
     box-sizing: border-box;
     outline: 0;
 }
-
-@import "colors";
-@import "_header";
-@import "_layout";
 
 body{
     font-family: 'Sora', sans-serif;


### PR DESCRIPTION
This pull request updates the way Sass stylesheets are imported and used across the codebase, moving from `@import` to the more modern `@use` syntax. It also fixes a typo in a CSS selector for hover states. These changes help improve maintainability and ensure better modularity in the stylesheet architecture.

**Sass import modernization:**

* Replaced all `@import` statements with `@use "colors" as *;` in `src/styles/_header.scss`, `src/styles/_layout.scss`, and `src/styles/main.scss` to adopt the recommended Sass module system. (`[[1]](diffhunk://#diff-b5111a0367b2cf279e1745afdf21cdc18959fc4806c3ef968e4f6c72a8299235R1-R2)`, `[[2]](diffhunk://#diff-59ef33c45ac0eaa09469ca3a4c4d9c88865c0db27bf27cf21ed8b35bb7b6dc13L1-R1)`, `[[3]](diffhunk://#diff-860167c28f76820d6936603389d222ebfd21f3b648774601a318cdd7bc345fb4R1-L11)`)
* Updated `src/styles/main.scss` to use `@use` for importing `header` and `layout` modules instead of `@import`, improving style encapsulation and modularity. (`[src/styles/main.scssR1-L11](diffhunk://#diff-860167c28f76820d6936603389d222ebfd21f3b648774601a318cdd7bc345fb4R1-L11)`)

**Bug fix:**

* Corrected a typo in the hover selector from `.header-button:houver` to `.header-button:hover` in `src/styles/_header.scss`, ensuring the hover styles are applied correctly. (`[src/styles/_header.scssL44-R46](diffhunk://#diff-b5111a0367b2cf279e1745afdf21cdc18959fc4806c3ef968e4f6c72a8299235L44-R46)`)