### PR TITLE
refactor: update vercel.json to use package.json for builds and remov…

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,6 @@
 {
   "version": 2,
   "builds": [
-    { "src": "gulpfile.js", "use": "@vercel/static-build", "config": { "distDir": "dist" } }
-  ],
-  "routes": [
-    { "src": "/(.*)", "dest": "/dist/$1" }
+    { "src": "package.json", "use": "@vercel/static-build", "config": { "distDir": "dist" } }
   ]
 }


### PR DESCRIPTION
This pull request makes a small update to the Vercel deployment configuration, changing the build entry point from `gulpfile.js` to `package.json` and removing custom routing rules. This simplifies the deployment process and aligns it with standard static build practices.…e unnecessary routes