### PR TITLE
refactor: remove vercel.json as it is no longer needed

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,0 @@
-{
-  "version": 2,
-  "builds": [
-    { "src": "package.json", "use": "@vercel/static-build", "config": { "distDir": "dist" } }
-  ]
-}


### PR DESCRIPTION
This pull request removes the `vercel.json` configuration file, which previously defined the Vercel deployment settings for the project. This suggests that Vercel is no longer being used for deployments, or that deployment is being handled differently.